### PR TITLE
Allow caller to override URL of Cryptowatch API

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ class CryptoWatch {
    * @constructor
    */
 
-  constructor() {
-    this.url = 'https://api.cryptowat.ch'
+  constructor(url = 'https://api.cryptowat.ch') {
+    this.url = url
   }
 
   /**


### PR DESCRIPTION
When this library is used in a browser, I'm getting the following error:
```
Failed to load https://api.cryptowat.ch/markets/prices: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://<my server>:3000' is therefore not allowed access.
```

This is because Cryptowatch API doesn't support CORS (for whatever reason).

The workaround is to call it by proxying queries through a server that I control, but to do so I need to change the URL that the library will query to point to my server, hence this diff